### PR TITLE
Add clarifiying note along with link to ES5 version of the guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 *A mostly reasonable approach to JavaScript*
 
-[For the ES5-only guide click here](es5/).
+NOTE: VHL uses the less cutting-edge EcmaScript 5 version of this Guide!  
+**[For the ES5-only guide click here](es5/)**.
 
 ## Table of Contents
 


### PR DESCRIPTION
Added a note to the front page README with a link pointing to the correct version of the guide to use (For browser support reasons, we use the es5 version, in a subdirectory, not the main, cutting-edge version).
